### PR TITLE
feat: integrated exercise seeding into database

### DIFF
--- a/backend/app/build.gradle.kts
+++ b/backend/app/build.gradle.kts
@@ -49,6 +49,9 @@ dependencies {
     implementation(libs.guava)
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // CSV
+    implementation("org.apache.commons:commons-csv:1.10.0")
 }
 
 // Apply a specific Java toolchain to ease working on different environments.

--- a/backend/app/src/main/kotlin/org/fitnessapp/Database.kt
+++ b/backend/app/src/main/kotlin/org/fitnessapp/Database.kt
@@ -5,6 +5,8 @@ import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.transactions.transaction
 
+import org.fitnessapp.data.seed.ExerciseSeeder
+
 fun initDatabase() {
     Database.connect(
         "jdbc:sqlite:fitness_app.db?foreign_keys=on",
@@ -31,5 +33,7 @@ fun initDatabase() {
             User
         )
     }
+
+    ExerciseSeeder.seedExercisesFromCsv()
 }
 

--- a/backend/app/src/main/kotlin/org/fitnessapp/data/ExerciseSeeder.kt
+++ b/backend/app/src/main/kotlin/org/fitnessapp/data/ExerciseSeeder.kt
@@ -1,0 +1,78 @@
+package org.fitnessapp.data.seed
+
+import org.apache.commons.csv.CSVFormat
+import org.apache.commons.csv.CSVParser
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import java.io.InputStreamReader
+
+import org.fitnessapp.models.Exercise
+import org.fitnessapp.models.ExerciseSeed
+
+object ExerciseSeeder {
+
+    fun seedExercisesFromCsv() {
+
+        val inputStream = object {}.javaClass
+            .getResourceAsStream("/data/exercises.csv")
+            ?: return println("CSV file not found — skipping seeding.")
+
+        InputStreamReader(inputStream).use { reader ->
+            CSVParser(
+                reader,
+                CSVFormat.DEFAULT.builder()
+                    .setHeader()
+                    .setSkipHeaderRecord(true)
+                    .build()
+            ).use { csvParser ->
+
+                var inserted = 0
+                var skipped = 0
+
+                // Get existing exercise names to avoid duplicates
+                val existingNames = transaction {
+                    Exercise.selectAll().mapNotNull { it[Exercise.name] }.toSet()
+                }
+
+                transaction {
+                    for (record in csvParser) {
+
+                        val name = record.get("name")?.trim()
+                        if (name.isNullOrBlank()) continue
+
+                        if (name in existingNames) {
+                            skipped++
+                            continue
+                        }
+
+                        // ✅ Map CSV → ExerciseSeed
+                        val exercise = ExerciseSeed(
+                            name = name,
+                            image = record.get("image")?.takeIf { it.isNotBlank() }
+                        )
+
+                        try {
+                            // ✅ Insert using ExerciseSeed
+                            Exercise.insert {
+                                it[Exercise.name] = exercise.name
+                                it[Exercise.image] = exercise.image
+                            }
+
+                            inserted++
+
+                        } catch (e: Exception) {
+                            println("Failed to insert '${exercise.name}': ${e.message}")
+                        }
+                    }
+                }
+
+                println(
+                    "\n✔ Exercise Seeding Complete\n" +
+                    "   Inserted: $inserted\n" +
+                    "   Skipped:  $skipped\n"
+                )
+            }
+        }
+    }
+}

--- a/backend/app/src/main/kotlin/org/fitnessapp/models/Exercise.kt
+++ b/backend/app/src/main/kotlin/org/fitnessapp/models/Exercise.kt
@@ -17,11 +17,16 @@ data class ExerciseDTO(
     val image: String?
 )
 
-@kotlinx.serialization.Serializable
+@Serializable
 data class ExerciseDetailDTO(
     val id: Long,
     val name: String,
     val image: String,
     val categoryIds: List<Long>,
     val muscleGroupIds: List<Long>
+)
+
+data class ExerciseSeed(
+    val name: String?,
+    val image: String?
 )

--- a/backend/app/src/main/resources/data/exercises.csv
+++ b/backend/app/src/main/resources/data/exercises.csv
@@ -1,0 +1,21 @@
+name,image
+Push Up,https://example.com/images/push-up.png
+Squat,https://example.com/images/squat.png
+Plank,https://example.com/images/plank.png
+Pull Up,https://example.com/images/pull-up.png
+Lunge,https://example.com/images/lunge.png
+Burpee,https://example.com/images/burpee.png
+Mountain Climber,https://example.com/images/mountain-climber.png
+Sit Up,https://example.com/images/sit-up.png
+Deadlift,https://example.com/images/deadlift.png
+Bench Press,https://example.com/images/bench-press.png
+Shoulder Press,https://example.com/images/shoulder-press.png
+Bicep Curl,https://example.com/images/bicep-curl.png
+Tricep Dip,https://example.com/images/tricep-dip.png
+Leg Press,https://example.com/images/leg-press.png
+Calf Raise,https://example.com/images/calf-raise.png
+Russian Twist,https://example.com/images/russian-twist.png
+Jumping Jacks,https://example.com/images/jumping-jacks.png
+High Knees,https://example.com/images/high-knees.png
+Glute Bridge,https://example.com/images/glute-bridge.png
+Side Plank,https://example.com/images/side-plank.png


### PR DESCRIPTION
### Description

Implemented database seeding for exercises using data from a CSV file. This allows the application to populate the exercise table with initial data automatically.

### Changes
* Added CSV file containing exercise data (name, image)
* Implemented ExerciseSeeder to read and parse CSV data
* Mapped CSV records to ExerciseSeed data model
* Inserted data into the database using Exposed ORM
* Prevented duplicate entries by checking existing records

### Notes
* Seeding runs during database initialization
* Designed to be idempotent (safe to run multiple times)
* Can be extended for additional entities in the future